### PR TITLE
release: release v2.0.0

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -25,6 +25,7 @@ body:
       label: Version
       description: What version did that bug occur in?
       options:
+        - v2.0.0
         - v1.3.3
         - v1.3.2
         - v1.3.1

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -40,6 +40,7 @@ Does this PR contain breaking changes?
 #### Checklist before release branch merge
 **IF NOT RELEVANT, DELETE THIS SECTION**
 - [ ] Update version - package.json, package-lock.json
+- [ ] Update README.md
 - [ ] Add version - issue templates
 
 

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ jobs:
 
     steps:
       - name: Run Issue PR Labeler
-        uses: hoho4190/issue-pr-labeler@v1
+        uses: hoho4190/issue-pr-labeler@v2.0.0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
 #          disable-bot: true
@@ -100,7 +100,6 @@ jobs:
 - Available events: `issues`, `pull_request`, `pull_request_target`
 - Use the `pull_request_target` event to allow Labeler to work even when you open a pull request from a forked repository to an upstream repository.
 
-> If it is not an available event, the workflow will display a warning message, but will result in a `Success` status. Not a `Failure` state.
 
 #### Input
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "issue-pr-labeler",
-  "version": "1.3.3",
+  "version": "2.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "issue-pr-labeler",
-      "version": "1.3.3",
+      "version": "2.0.0",
       "license": "MIT",
       "dependencies": {
         "@actions/core": "^1.10.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "issue-pr-labeler",
-  "version": "1.3.3",
+  "version": "2.0.0",
   "private": true,
   "description": "Automatically add labels by filtering the title and comment of issues and pull requests.",
   "main": "lib/main.js",


### PR DESCRIPTION
## Description

**upgrade node from 16 to 20**

- build(deps): bump codecov/codecov-action from 3 to 4 @dependabot (#152)
- build(deps): bump actions/upload-artifact from 3 to 4 @dependabot (#154)
- build(deps): bump github/codeql-action from 2 to 3 @dependabot (#153)
- build: upgrade node to 20 @hoho4190 (#151)

> https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Test (adding missing tests, correcting existing tests)
- [ ] Code style update (typo, formatting, local variables)
- [x] Build related changes
- [ ] CI related changes
- [ ] Chore (etc)
- [ ] Documentation content changes
- [x] Release new version


## Whether Braking Changes
Does this PR contain breaking changes?

- [ ] Yes
- [x] NO


## Checklist before merge

- [x] Updating the `dist` folder


## Checklist after merge

- N/A
