### PR TITLE
ci: update GitHub action tags

### DIFF
--- a/.github/workflows/pr-event-trigger.yml
+++ b/.github/workflows/pr-event-trigger.yml
@@ -18,7 +18,7 @@ jobs:
 
     steps:
       - name: Run Issue PR Labeler
-        uses: hoho4190/issue-pr-labeler@v2.0.0
+        uses: hoho4190/issue-pr-labeler@v2
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
         

--- a/.github/workflows/pr-event-trigger.yml
+++ b/.github/workflows/pr-event-trigger.yml
@@ -36,7 +36,7 @@ jobs:
 
     steps:
       - name: Update release draft
-        uses: release-drafter/release-drafter@v6.1.0
+        uses: release-drafter/release-drafter@v6
         with:
           config-name: release-drafter-config.yml
         env:

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ jobs:
 
     steps:
       - name: Run Issue PR Labeler
-        uses: hoho4190/issue-pr-labeler@v2.0.0
+        uses: hoho4190/issue-pr-labeler@v2
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
 #          disable-bot: true


### PR DESCRIPTION
## Description

Update GitHub Action tags to use major versions.
- issue-pr-labeler(v2)
- release-drafter(v6)

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Test (adding missing tests, correcting existing tests)
- [ ] Code style update (typo, formatting, local variables)
- [ ] Build related changes
- [x] CI related changes
- [ ] Chore (etc)
- [ ] Documentation content changes
- [ ] Release new version


## Whether Braking Changes
Does this PR contain breaking changes?

- [ ] Yes
- [x] NO


## Checklist before merge

- N/A


## Checklist after merge

- N/A
