### PR TITLE
fix(ci): update release drafter category labels

### DIFF
--- a/.github/release-drafter-config.yml
+++ b/.github/release-drafter-config.yml
@@ -14,7 +14,7 @@ categories:
     labels:
       - 'type: 🐛 fix'
   - title: '🧰 Maintenance'
-    label:
+    labels:
       - 'type: ♻️ refactor'
       - 'type: 🧪 test'
       - 'type: 🎨 style'
@@ -23,7 +23,7 @@ categories:
       - 'type: 🧹 chore'
       - 'dependencies'
   - title: '📚 Documentation'
-    label:
+    labels:
       - 'type: 📚 docs'
 change-template: '- $TITLE @$AUTHOR (#$NUMBER)'
 change-title-escapes: '\<*_&' # You can add # and @ to disable mentions, and add ` to disable code blocks.


### PR DESCRIPTION
## Summary

This PR fixes the Release Drafter v7 configuration validation error by using `labels` for multi-label categories.

#### Related issues

Related to #427

## Changes

- Updated Release Drafter category entries that use multiple labels from `label` to `labels`
- Kept the existing release note categorization behavior unchanged

## Type of change

<!-- textlint-disable -->

- [ ] ✨ New feature
- [x] 🐛 Bug fix
- [ ] ♻️ Refactoring (no functional or API changes)
- [ ] 🧪 Test (add or fix tests)
- [ ] 🎨 Code style (formatting, comments, naming)
- [ ] 🏗️ Build-related changes
- [x] ⚙️ CI/CD changes
- [ ] 🧹 Chore (cleanup, misc.)
- [ ] 📚 Documentation changes

<!-- textlint-enable -->

## Breaking Changes

- [ ] Breaking change

> If checked, explain what breaks and what users need to know.

## Testing

- [ ] Added tests for new functionality.
- [ ] Verified that existing tests pass after changes to existing functionality.
- [ ] Improved test coverage or updated existing tests.
- [x] N/A – this change does not require tests.

Validation performed:

```text
release-drafter v7 category schema validation passed
```

## Pre-Merge Checklist

- [ ] `dist/` directory updated

## Additional Notes

This fixes the config schema issue exposed after upgrading `release-drafter/release-drafter` from v6 to v7. In v7, `label` is a single string and `labels` is the array form.

<!-- Created by: hoho4190 -->
