### PR TITLE
chore(lint): migrate super-linter to v8.6.0

### DIFF
--- a/.devcontainer/devcontainer-lock.json
+++ b/.devcontainer/devcontainer-lock.json
@@ -1,0 +1,29 @@
+{
+  "features": {
+    "ghcr.io/devcontainers-extra/features/ripgrep:1": {
+      "version": "1.0.15",
+      "resolved": "ghcr.io/devcontainers-extra/features/ripgrep@sha256:0dfc0ac16f0d6aa754d006a138fd4cb4a62c245d308306edf8ad1b7a80b8fdf2",
+      "integrity": "sha256:0dfc0ac16f0d6aa754d006a138fd4cb4a62c245d308306edf8ad1b7a80b8fdf2"
+    },
+    "ghcr.io/devcontainers-extra/features/shellcheck:1": {
+      "version": "1.1.0",
+      "resolved": "ghcr.io/devcontainers-extra/features/shellcheck@sha256:8e6d050e4ead6a0350dbe4c70611e351f32cb61a8cc5cb2b39da0cf29ff3bed5",
+      "integrity": "sha256:8e6d050e4ead6a0350dbe4c70611e351f32cb61a8cc5cb2b39da0cf29ff3bed5"
+    },
+    "ghcr.io/devcontainers-extra/features/shfmt:1": {
+      "version": "1.0.2",
+      "resolved": "ghcr.io/devcontainers-extra/features/shfmt@sha256:9d87bdd69e7b37554488291e79b37a40d1e18beddfa151454570d5bf72423df8",
+      "integrity": "sha256:9d87bdd69e7b37554488291e79b37a40d1e18beddfa151454570d5bf72423df8"
+    },
+    "ghcr.io/devcontainers/features/docker-in-docker:2": {
+      "version": "2.17.0",
+      "resolved": "ghcr.io/devcontainers/features/docker-in-docker@sha256:25b9f05705ffba7dbe503230ac76081419306f8c8bc88e0ce78c4ecd99a0c78c",
+      "integrity": "sha256:25b9f05705ffba7dbe503230ac76081419306f8c8bc88e0ce78c4ecd99a0c78c"
+    },
+    "ghcr.io/devcontainers/features/github-cli:1": {
+      "version": "1.1.0",
+      "resolved": "ghcr.io/devcontainers/features/github-cli@sha256:d22f50b70ed75339b4eed1ba9ecde3a1791f90e88d37936517e3bace0bbad671",
+      "integrity": "sha256:d22f50b70ed75339b4eed1ba9ecde3a1791f90e88d37936517e3bace0bbad671"
+    }
+  }
+}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -60,7 +60,7 @@
     }
   },
   "containerEnv": {
-    "SUPER_LINTER_TAG": "slim-v8.5.0"
+    "SUPER_LINTER_TAG": "slim-v8.6.0"
   },
   "remoteEnv": {},
   "features": {
@@ -68,7 +68,7 @@
     "ghcr.io/devcontainers/features/docker-in-docker:2": {},
     "ghcr.io/devcontainers-extra/features/ripgrep:1": {},
     "ghcr.io/devcontainers-extra/features/shfmt:1": {
-      "version": "3.12.0" // shfmt version aligned with the Super-Linter image tag
+      "version": "3.13.0" // shfmt version aligned with the Super-Linter image tag
     },
     "ghcr.io/devcontainers-extra/features/shellcheck:1": {
       "version": "0.11.0" // ShellCheck version aligned with the Super-Linter image tag

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -52,7 +52,10 @@
         },
 
         // timonwong.shellcheck: use shellcheck binary installed in the container
-        "shellcheck.executablePath": "/usr/local/bin/shellcheck"
+        "shellcheck.executablePath": "/usr/local/bin/shellcheck",
+
+        // gruntfuggly.todo-tree: use ripgrep binary installed in the container
+        "todo-tree.ripgrep.ripgrep": "/usr/local/bin/rg"
       }
     }
   },
@@ -63,6 +66,7 @@
   "features": {
     "ghcr.io/devcontainers/features/github-cli:1": {},
     "ghcr.io/devcontainers/features/docker-in-docker:2": {},
+    "ghcr.io/devcontainers-extra/features/ripgrep:1": {},
     "ghcr.io/devcontainers-extra/features/shfmt:1": {
       "version": "3.12.0" // shfmt version aligned with the Super-Linter image tag
     },

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,8 @@ updates:
     open-pull-requests-limit: 5
     assignees:
       - 'hoho4190'
+    ignore:
+      - dependency-name: 'super-linter/super-linter'
     groups:
       actions:
         update-types:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,6 +16,7 @@ jobs:
     name: Build
 
     runs-on: ubuntu-latest
+    environment: ci
 
     permissions:
       contents: write

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,7 +16,9 @@ jobs:
     name: Build
 
     runs-on: ubuntu-latest
-    environment: ci
+    environment:
+      name: ci
+      deployment: false
 
     permissions:
       contents: write

--- a/.github/workflows/lint-check.yml
+++ b/.github/workflows/lint-check.yml
@@ -38,7 +38,7 @@ jobs:
           grep -Ev '^(#|$)' .github/.super-linter.env >> "$GITHUB_ENV"
 
       - name: Run Super-Linter
-        uses: super-linter/super-linter/slim@v8.5.0
+        uses: super-linter/super-linter/slim@v8.6.0
         env:
           DEFAULT_BRANCH: main
           ENABLE_GITHUB_PULL_REQUEST_SUMMARY_COMMENT: 'true'

--- a/.github/workflows/release-prepare.yml
+++ b/.github/workflows/release-prepare.yml
@@ -13,7 +13,9 @@ jobs:
     if: ${{ github.event.ref_type == 'branch' && startsWith(github.ref, 'refs/heads/release/v') }}
 
     runs-on: ubuntu-latest
-    environment: release
+    environment:
+      name: release
+      deployment: false
 
     permissions:
       contents: write

--- a/.github/workflows/release-prepare.yml
+++ b/.github/workflows/release-prepare.yml
@@ -13,6 +13,7 @@ jobs:
     if: ${{ github.event.ref_type == 'branch' && startsWith(github.ref, 'refs/heads/release/v') }}
 
     runs-on: ubuntu-latest
+    environment: release
 
     permissions:
       contents: write

--- a/scripts/super-linter/run-super-linter.sh
+++ b/scripts/super-linter/run-super-linter.sh
@@ -10,7 +10,7 @@ readonly ENV_PATH="${ROOT_DIR}/.github/.super-linter.env"
 readonly RUN_TYPE="${1:-lint-all}"
 
 if [[ -z "${SUPER_LINTER_TAG:-}" ]]; then
-    echo "SUPER_LINTER_TAG environment variable is required (e.g., slim-v8.5.0)."
+    echo "SUPER_LINTER_TAG environment variable is required (e.g., slim-vX.X.X)."
     exit 1
 fi
 


### PR DESCRIPTION
## Summary

This PR migrates Super-Linter from v8.5.0 to v8.6.0 and updates the local development setup to match the new image.

#### Related issues

N/A

## Changes

- Updated the Super-Linter workflow to use `super-linter/super-linter/slim@v8.6.0`.
- Updated the devcontainer `SUPER_LINTER_TAG` to `slim-v8.6.0`.
- Aligned the local `shfmt` version with the Super-Linter v8.6.0 image.
- Added `ci` and `release` workflow environments so `zizmor v1.23.1` passes `secrets-outside-env` checks.
- Added the generated devcontainer lock file.

## Type of change

<!-- textlint-disable -->

- [ ] ✨ New feature
- [ ] 🐛 Bug fix
- [ ] ♻️ Refactoring (no functional or API changes)
- [ ] 🧪 Test (add or fix tests)
- [ ] 🎨 Code style (formatting, comments, naming)
- [x] 🏗️ Build-related changes
- [x] ⚙️ CI/CD changes
- [x] 🧹 Chore (cleanup, misc.)
- [ ] 📚 Documentation changes

<!-- textlint-enable -->

## Breaking Changes

- [ ] Breaking change

> If checked, explain what breaks and what users need to know.

## Testing

- [ ] Added tests for new functionality.
- [x] Verified that existing tests pass after changes to existing functionality.
- [ ] Improved test coverage or updated existing tests.
- [ ] N/A – this change does not require tests.

## Pre-Merge Checklist

- [x] `dist/` directory updated

## Additional Notes

Validation completed locally:

- `npm run all`
- `bash scripts/super-linter/run-super-linter.sh lint-all`

GitHub repository environments were configured manually:

- `ci` for `CODECOV_TOKEN`
- `release` for `RELEASE_PREPARE_PAT`

<!-- Created by: hoho4190 -->