### PR TITLE
fix(ci): trigger checks after dist sync push

### DIFF
--- a/.github/workflows/dist-sync.yml
+++ b/.github/workflows/dist-sync.yml
@@ -16,6 +16,9 @@ jobs:
 
     if: ${{ github.ref_type == 'branch' && github.ref_name != 'main' }}
     runs-on: ubuntu-latest
+    environment:
+      name: ci
+      deployment: false
 
     steps:
       - name: Checkout selected branch
@@ -39,5 +42,5 @@ jobs:
       - name: Commit and push synced dist
         env:
           BRANCH_NAME: ${{ github.ref_name }}
-          GIT_PUSH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GIT_PUSH_TOKEN: ${{ secrets.DIST_SYNC_PAT }}
         run: bash .github/scripts/dist-sync/dist-sync.sh


### PR DESCRIPTION
## Summary

This PR updates the dist sync workflow so commits created by the manual dist sync job can trigger follow-up CI checks on pull requests.

#### Related issues

N/A

## Changes

- Replaced the dist sync push token with `secrets.DIST_SYNC_PAT`.
- Added the `ci` environment to the dist sync job so the PAT is accessed through a dedicated environment.
- Keeps the existing dist sync build and commit flow unchanged.

## Type of change

<!-- textlint-disable -->

- [ ] ✨ New feature
- [x] 🐛 Bug fix
- [ ] ♻️ Refactoring (no functional or API changes)
- [ ] 🧪 Test (add or fix tests)
- [ ] 🎨 Code style (formatting, comments, naming)
- [ ] 🏗️ Build-related changes
- [x] ⚙️ CI/CD changes
- [ ] 🧹 Chore (cleanup, misc.)
- [ ] 📚 Documentation changes

<!-- textlint-enable -->

## Breaking Changes

- [ ] Breaking change

> If checked, explain what breaks and what users need to know.

## Testing

- [ ] Added tests for new functionality.
- [x] Verified that existing tests pass after changes to existing functionality.
- [ ] Improved test coverage or updated existing tests.
- [ ] N/A – this change does not require tests.

## Pre-Merge Checklist

- [ ] `dist/` directory updated

## Additional Notes

`dist/` was not updated because this is a workflow-only change. The `DIST_SYNC_PAT` secret must be available to the `ci` environment.

<!-- Created by: hoho4190 -->